### PR TITLE
Fikset linken til Designsystem / Guidelines-sidene

### DIFF
--- a/guideline-app/README.design.md
+++ b/guideline-app/README.design.md
@@ -12,13 +12,13 @@ Informasjonen man kan si noe om er:
 - Krav og retningslinjer til universell utforming 
 
 Alle endringer som blir gjort i filene i disse undermappene, vil sørge for at neste versjon som
-legges ut av [Guidelines-siden](https://navikt.github.com/nav-frontend-moduler) får med seg de
+legges ut av [Guidelines-siden](https://navikt.github.io/nav-frontend-moduler) får med seg de
 oppdateringene som har blitt lagt inn.
 
 
 ### Filstandard
 
-På [Guidelines-siden](https://navikt.github.com/nav-frontend-moduler) har hver enkelt komponent
+På [Guidelines-siden](https://navikt.github.io/nav-frontend-moduler) har hver enkelt komponent
 (under menyvalget "Komponenter"), fått en egen artikkel, som består av:
 1. En ingress som sier noe overordnet og generelt om komponenten
 3. En tekst som beskriver hvordan komponenten er tenkt å tas i bruk


### PR DESCRIPTION
endret fra .com til .io